### PR TITLE
feat: example of CLI for running manual migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See [Yokai documentation](https://ankorstore.github.io/yokai).
 
 ## Demo applications
 
-| Application                | Description                   |
-|----------------------------|-------------------------------|
-| [http-demo](http-demo)     | HTTP API demo application |
+| Application                | Description                     |
+|----------------------------|---------------------------------|
+| [http-demo](http-demo)     | HTTP API demo application       |
 | [worker-demo](worker-demo) | Pub/Sub worker demo application |

--- a/http-demo/cmd/migrate.go
+++ b/http-demo/cmd/migrate.go
@@ -31,11 +31,9 @@ var migrateCmd = &cobra.Command{
 				err := db.AutoMigrate(&model.Gopher{})
 				if err != nil {
 					logger.Error().Err(err).Msg("error during ORM auto migration")
-
-					return err
+				} else {
+					logger.Info().Msg("ORM auto migration success")
 				}
-
-				logger.Info().Msg("ORM auto migration success")
 
 				return sd.Shutdown()
 			}),

--- a/http-demo/cmd/migrate.go
+++ b/http-demo/cmd/migrate.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"github.com/ankorstore/yokai-showroom/http-demo/internal/model"
+	"github.com/ankorstore/yokai/fxcore"
+	"github.com/ankorstore/yokai/fxorm"
+	"github.com/ankorstore/yokai/log"
+	"github.com/spf13/cobra"
+	"go.uber.org/fx"
+	"gorm.io/gorm"
+)
+
+func init() {
+	rootCmd.AddCommand(migrateCmd)
+}
+
+var migrateCmd = &cobra.Command{
+	Use:   "migrate",
+	Short: "Run application ORM migrations",
+	Run: func(cmd *cobra.Command, args []string) {
+
+		bootstrapper := fxcore.NewBootstrapper().WithOptions(
+			// modules
+			fxorm.FxOrmModule,
+		)
+
+		bootstrapper.WithContext(cmd.Context()).RunApp(
+			fx.Invoke(func(logger *log.Logger, db *gorm.DB, sd fx.Shutdowner) error {
+				logger.Info().Msg("starting ORM auto migration")
+
+				err := db.AutoMigrate(&model.Gopher{})
+				if err != nil {
+					logger.Error().Err(err).Msg("error during ORM auto migration")
+
+					return err
+				}
+
+				logger.Info().Msg("ORM auto migration success")
+
+				return sd.Shutdown()
+			}),
+		)
+	},
+}

--- a/http-demo/dev.Dockerfile
+++ b/http-demo/dev.Dockerfile
@@ -4,4 +4,5 @@ RUN go install github.com/cosmtrek/air@v1.49.0
 
 WORKDIR /app
 
-CMD ["air", "-c", ".air.toml", "--", "run"]
+ENTRYPOINT ["air", "-c", ".air.toml", "--"]
+CMD ["run"]

--- a/http-demo/docker-compose.yaml
+++ b/http-demo/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
     build:
       dockerfile: dev.Dockerfile
       context: .
+    command: ["run"]
     networks:
       - http-demo
     ports:
@@ -19,12 +20,36 @@ services:
     env_file:
       - .env
 
+  http-demo-migration:
+    container_name: http-demo-migration
+    build:
+      dockerfile: dev.Dockerfile
+      context: .
+    command: ["migrate"]
+    depends_on:
+      http-demo-database:
+        condition: service_healthy
+    networks:
+      - http-demo
+    volumes:
+      - .:/app
+    env_file:
+      - .env
+
   http-demo-database:
     container_name: http-demo-database
     image: mysql:8
     restart: always
     networks:
       - http-demo
+    healthcheck:
+      test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
+      timeout: 20s
+      retries: 10
+    ports:
+      - "3306:3306"
+    expose:
+      - "3306"
     volumes:
       - http-demo-database-data:/var/lib/mysql
     env_file:

--- a/http-demo/internal/bootstrap.go
+++ b/http-demo/internal/bootstrap.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ankorstore/yokai-showroom/http-demo/internal/model"
 	"github.com/ankorstore/yokai/fxcore"
 	"github.com/ankorstore/yokai/fxhttpserver"
 	"github.com/ankorstore/yokai/fxorm"
@@ -29,10 +28,7 @@ func init() {
 }
 
 func Run(ctx context.Context) {
-	Bootstrapper.WithContext(ctx).RunApp(
-		// run orm migrations
-		fxorm.RunFxOrmAutoMigrate(&model.Gopher{}),
-	)
+	Bootstrapper.WithContext(ctx).RunApp()
 }
 
 func RunTest(tb testing.TB, options ...fx.Option) {
@@ -47,8 +43,6 @@ func RunTest(tb testing.TB, options ...fx.Option) {
 
 	Bootstrapper.RunTestApp(
 		tb,
-		// run orm migrations
-		fxorm.RunFxOrmAutoMigrate(&model.Gopher{}),
 		// apply per test options
 		fx.Options(options...),
 	)


### PR DESCRIPTION
Changes:
- disabled auto migrations from app bootstrapper
- created a dedicated cli `app migrate` to start only what's needed in Yokai to run migrations
- adapted docker compose stack to have a dedicated migration container

Run migrations:
- update the model
- simply run `docker compose run http-demo-migration`
- check DB impacts

Notes:
- this is just an example, here I'm using a Go Air container to run migrations, which is very unoptimized.
